### PR TITLE
override another method of the SecurityManager

### DIFF
--- a/src/main/java/org/junit/contrib/java/lang/system/ExpectedSystemExit.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/ExpectedSystemExit.java
@@ -102,6 +102,11 @@ public class ExpectedSystemExit implements TestRule {
 
 	private static class NoExitSecurityManager extends SecurityManager {
 		@Override
+		public void checkPermission(Permission perm, Object context) {
+			// allow anything.
+		}
+
+		@Override
 		public void checkPermission(Permission perm) {
 			// allow anything.
 		}


### PR DESCRIPTION
With the original version, I failed to access the JMX bean server or it's registry.
