### PR TITLE
The "new PrintStream(log)" use system default encoding, then it makes en...

### DIFF
--- a/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
@@ -13,7 +13,7 @@ public abstract class PrintStreamLog extends ExternalResource {
 	@Override
 	protected void before() throws Throwable {
 		originalStream = getOriginalStream();
-		PrintStream wrappedLog = new PrintStream(log);
+		PrintStream wrappedLog = new PrintStream(log, false, "UTF-8");
 		setStream(wrappedLog);
 	}
 


### PR DESCRIPTION
...coding problem on Windows.

you should specify UTF-8 explicitly. you can use 'new PrintStream(log, false, "UTF-8")', to fix it.
