### PR TITLE
Use StandardOutputStreamLog and StandardErrorStreamLog and optionally keep logging to the console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,13 +134,12 @@
 			<artifactId>junit-dep</artifactId>
 			<version>[4.9,)</version>
 		</dependency>
-
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>[2.0,)</version>
-			<scope>test</scope>
+			<version>2.4</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>

--- a/src/main/java/org/junit/contrib/java/lang/system/StandardErrorStreamLog.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/StandardErrorStreamLog.java
@@ -25,6 +25,14 @@ import org.junit.contrib.java.lang.system.internal.PrintStreamLog;
  * </pre>
  */
 public class StandardErrorStreamLog extends PrintStreamLog {
+
+	public StandardErrorStreamLog() {
+	}
+	
+	public StandardErrorStreamLog(boolean keepOutput) {
+		super(keepOutput);
+	}
+	
 	@Override
 	protected PrintStream getOriginalStream() {
 		return err;

--- a/src/main/java/org/junit/contrib/java/lang/system/StandardOutputStreamLog.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/StandardOutputStreamLog.java
@@ -25,6 +25,14 @@ import org.junit.contrib.java.lang.system.internal.PrintStreamLog;
  * </pre>
  */
 public class StandardOutputStreamLog extends PrintStreamLog {
+	
+	public StandardOutputStreamLog() {
+	}
+	
+	public StandardOutputStreamLog(boolean keepOutput) {
+		super(keepOutput);
+	}
+	
 	@Override
 	protected PrintStream getOriginalStream() {
 		return out;

--- a/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
@@ -1,9 +1,11 @@
 package org.junit.contrib.java.lang.system.internal;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 
+import org.apache.commons.io.output.TeeOutputStream;
 import org.junit.rules.ExternalResource;
 
 public abstract class PrintStreamLog extends ExternalResource {
@@ -11,11 +13,34 @@ public abstract class PrintStreamLog extends ExternalResource {
 	private static final String ENCODING = "UTF-8";
 	private final ByteArrayOutputStream log = new ByteArrayOutputStream();
 	private PrintStream originalStream;
+	protected final boolean keepOutput;
+	
+	/**
+	 * Default: will redirect to {@link #log}
+	 */
+	public PrintStreamLog() {
+		keepOutput = false;
+	}
 
+	/**
+	 * Allow to keep printing the output in the original Stream
+	 * 
+	 * @param keepOutput true to print in the readable {@link ByteArrayInputStream} and in the original stream at the same time
+	 */
+	public PrintStreamLog(boolean keepOutput) {
+		this.keepOutput = keepOutput;
+	}
+	
 	@Override
 	protected void before() throws Throwable {
 		originalStream = getOriginalStream();
 		PrintStream wrappedLog = new PrintStream(log, NO_AUTO_FLUSH, ENCODING);
+		if(keepOutput) {
+			wrappedLog = new PrintStream(new TeeOutputStream(log, originalStream), NO_AUTO_FLUSH, ENCODING);
+		}
+		else {
+			wrappedLog = new PrintStream(log, NO_AUTO_FLUSH, ENCODING);
+		}
 		setStream(wrappedLog);
 	}
 

--- a/src/test/java/org/junit/contrib/java/lang/system/StandardOutputStreamLogTest.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/StandardOutputStreamLogTest.java
@@ -7,14 +7,35 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
 import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.model.Statement;
 
+@RunWith(value = Parameterized.class)
 public class StandardOutputStreamLogTest {
 	private static final String ARBITRARY_TEXT = "arbitrary text";
 
-	private final StandardOutputStreamLog log = new StandardOutputStreamLog();
+	private final StandardOutputStreamLog log;
+
+	@Parameters
+	public static Collection<Object[]> data() {
+		Object[][] data = new Object[][] { { null }, { Boolean.TRUE }, { Boolean.FALSE } };
+		return Arrays.asList(data);
+	}
+
+	public StandardOutputStreamLogTest(Boolean keepOutput) {
+		if (keepOutput == null) {
+			log = new StandardOutputStreamLog();
+		}
+		else {
+			log = new StandardOutputStreamLog(keepOutput);
+		}
+	}
 
 	@Test
 	public void logWriting() throws Throwable {

--- a/src/test/java/org/junit/contrib/java/lang/system/example/PrintLog.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/example/PrintLog.java
@@ -1,0 +1,8 @@
+package org.junit.contrib.java.lang.system.example;
+
+public class PrintLog {
+	public void doPrint(String s) {
+		System.out.print(s);
+		System.err.print(s);
+	}
+}

--- a/src/test/java/org/junit/contrib/java/lang/system/example/PrintLogTest.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/example/PrintLogTest.java
@@ -1,0 +1,32 @@
+package org.junit.contrib.java.lang.system.example;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.StandardErrorStreamLog;
+import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+
+public class PrintLogTest {
+	
+	PrintLog app = new PrintLog();
+	String s = "some test";
+	
+	/**
+	 * logging to sysout will not print in the console anymore:
+	 */
+	@Rule
+	public StandardOutputStreamLog out = new StandardOutputStreamLog(false);
+	
+	/**
+	 * logging to syserr will still be shown in the console:
+	 */
+	@Rule
+	public StandardErrorStreamLog err = new StandardErrorStreamLog(true);
+	
+	@Test
+	public void testDoPrint() {
+		app.doPrint(s);
+		Assert.assertEquals(s, out.getLog());
+		Assert.assertEquals(s, err.getLog());
+	}
+}


### PR DESCRIPTION
  Hello,
system-rules is a good way to check what is printed to the console, but it's a bit annoying to lose all the logs (especially when you write the assertions on these logs, need to count lines, write regexp, understand why it fails...).

So I thought it would be nice to have some way to get this log, and still see it in the Console, I juste used a TeeInputStream to write at the same time in the ByteArray and in the sysout.

I added some usage example, and parameterized the unit test to test all constructors.

Regards
