### PR TITLE
Use concrete versions rather than ranges for a more reproducible build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
-			<artifactId>junit-dep</artifactId>
-			<version>4.9</version>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
@@ -75,13 +75,13 @@
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>
-			<version>1.2</version>
+			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-library</artifactId>
-			<version>1.2</version>
+			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This is a simple, but opinionated, change to use concrete versions instead of ranges. This makes the build more reproducible, so later releases or possible snapshots don't cause breakage. The versions picked are the ones necessary to build (and test) system-rules, although it will still run with earlier versions.

I encountered this when a build using system-rules started trying to bring in a snapshot build of `junit-dep` as a transitive dependency. These were then the changes necessary to get it building. Current JUnit releases don't repackage dependencies in `junit:junit`, so `junit:junit-dep` is no longer necessary.
