### PR TITLE
Add log-on-failure mode

### DIFF
--- a/src/main/java/org/junit/contrib/java/lang/system/LogMode.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/LogMode.java
@@ -13,5 +13,10 @@ public enum LogMode {
 	/**
 	 * Record the writes while they are still written to the stream.
 	 */
-	LOG_AND_WRITE_TO_STREAM
+	LOG_AND_WRITE_TO_STREAM,
+
+	/**
+	 * Capture the writes to the stream.  On test failure write to the original stream.
+	 */
+	LOG_ONLY_ON_FAILURE
 }

--- a/src/main/java/org/junit/contrib/java/lang/system/LogMode.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/LogMode.java
@@ -18,5 +18,5 @@ public enum LogMode {
 	/**
 	 * Capture the writes to the stream.  On test failure write to the original stream.
 	 */
-	LOG_ONLY_ON_FAILURE
+	LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY
 }

--- a/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
@@ -31,24 +31,15 @@ public abstract class PrintStreamLog extends TestWatcher {
 					NO_AUTO_FLUSH, ENCODING);
 			setStream(wrappedStream);
 		} catch (UnsupportedEncodingException e) {
-			throw new Error(e); // JRE missing UTF-8
+			throw new RuntimeException(e); // JRE missing UTF-8
 		}
 	}
 
 	@Override
 	protected void failed(Throwable e, Description description) {
 		// Only log-on-failure mode needs to print; the others already handle this
-		switch (mode) {
-			case LOG_AND_WRITE_TO_STREAM:
-			case LOG_ONLY:
-				break;
-			case LOG_ONLY_ON_FAILURE:
-				originalStream.print(getLog());
-				break;
-			default:
-				throw new IllegalArgumentException("The LogMode " + mode
-						+ " is not supported");
-		}
+		if (mode == LogMode.LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY)
+			originalStream.print(getLog());
 	}
 
 	@Override
@@ -61,7 +52,7 @@ public abstract class PrintStreamLog extends TestWatcher {
 			case LOG_AND_WRITE_TO_STREAM:
 				return new TeeOutputStream(originalStream, log);
 			case LOG_ONLY:
-			case LOG_ONLY_ON_FAILURE:
+			case LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY:
 				return log;
 			default:
 				throw new IllegalArgumentException("The LogMode " + mode

--- a/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
@@ -1,15 +1,16 @@
 package org.junit.contrib.java.lang.system.internal;
 
+import org.apache.commons.io.output.TeeOutputStream;
+import org.junit.contrib.java.lang.system.LogMode;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 
-import org.apache.commons.io.output.TeeOutputStream;
-import org.junit.contrib.java.lang.system.LogMode;
-import org.junit.rules.ExternalResource;
-
-public abstract class PrintStreamLog extends ExternalResource {
+public abstract class PrintStreamLog extends TestWatcher {
 	private static final boolean NO_AUTO_FLUSH = false;
 	private static final String ENCODING = "UTF-8";
 	private final ByteArrayOutputStream log = new ByteArrayOutputStream();
@@ -23,14 +24,22 @@ public abstract class PrintStreamLog extends ExternalResource {
 	}
 
 	@Override
-	protected void before() throws Throwable {
-		originalStream = getOriginalStream();
-		PrintStream wrappedStream = new PrintStream(getNewStream(), NO_AUTO_FLUSH,
-			ENCODING);
-		setStream(wrappedStream);
+	protected void starting(Description description) {
+		try {
+			originalStream = getOriginalStream();
+			PrintStream wrappedStream = new PrintStream(getNewStream(), NO_AUTO_FLUSH, ENCODING);
+			setStream(wrappedStream);
+		} catch (UnsupportedEncodingException e) {
+			throw new Error(e); // JRE missing UTF-8
+		}
 	}
 
-	private OutputStream getNewStream() throws UnsupportedEncodingException {
+	@Override
+	protected void finished(Description description) {
+		setStream(originalStream);
+	}
+
+	private OutputStream getNewStream() {
 		switch (mode) {
 			case LOG_AND_WRITE_TO_STREAM:
 				return new TeeOutputStream(originalStream, log);
@@ -40,11 +49,6 @@ public abstract class PrintStreamLog extends ExternalResource {
 				throw new IllegalArgumentException("The LogMode " + mode
 					+ " is not supported");
 		}
-	}
-
-	@Override
-	protected void after() {
-		setStream(originalStream);
 	}
 
 	protected abstract PrintStream getOriginalStream();

--- a/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
@@ -1,14 +1,14 @@
 package org.junit.contrib.java.lang.system.internal;
 
-import org.apache.commons.io.output.TeeOutputStream;
-import org.junit.contrib.java.lang.system.LogMode;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
-
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+
+import org.apache.commons.io.output.TeeOutputStream;
+import org.junit.contrib.java.lang.system.LogMode;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 public abstract class PrintStreamLog extends TestWatcher {
 	private static final boolean NO_AUTO_FLUSH = false;

--- a/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/internal/PrintStreamLog.java
@@ -27,10 +27,27 @@ public abstract class PrintStreamLog extends TestWatcher {
 	protected void starting(Description description) {
 		try {
 			originalStream = getOriginalStream();
-			PrintStream wrappedStream = new PrintStream(getNewStream(), NO_AUTO_FLUSH, ENCODING);
+			PrintStream wrappedStream = new PrintStream(getNewStream(),
+					NO_AUTO_FLUSH, ENCODING);
 			setStream(wrappedStream);
 		} catch (UnsupportedEncodingException e) {
 			throw new Error(e); // JRE missing UTF-8
+		}
+	}
+
+	@Override
+	protected void failed(Throwable e, Description description) {
+		// Only log-on-failure mode needs to print; the others already handle this
+		switch (mode) {
+			case LOG_AND_WRITE_TO_STREAM:
+			case LOG_ONLY:
+				break;
+			case LOG_ONLY_ON_FAILURE:
+				originalStream.print(getLog());
+				break;
+			default:
+				throw new IllegalArgumentException("The LogMode " + mode
+						+ " is not supported");
 		}
 	}
 
@@ -44,6 +61,7 @@ public abstract class PrintStreamLog extends TestWatcher {
 			case LOG_AND_WRITE_TO_STREAM:
 				return new TeeOutputStream(originalStream, log);
 			case LOG_ONLY:
+			case LOG_ONLY_ON_FAILURE:
 				return log;
 			default:
 				throw new IllegalArgumentException("The LogMode " + mode

--- a/src/test/java/org/junit/contrib/java/lang/system/PrintStreamLogOnFailureTest.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/PrintStreamLogOnFailureTest.java
@@ -1,0 +1,207 @@
+/*
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>.
+ */
+
+package org.junit.contrib.java.lang.system;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static java.lang.System.err;
+import static java.lang.System.out;
+import static java.lang.System.setErr;
+import static java.lang.System.setOut;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.junit.Assert.assertThat;
+
+public class PrintStreamLogOnFailureTest {
+	private static final String ARBITRARY_TEXT = "arbitrary text";
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void doesNotWriteToSystemOutputStreamForLogOnFailureModeWithoutFailure() throws Throwable {
+		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		PrintStream originalStream = out;
+		try {
+			ByteArrayOutputStream captureOutputStream = new ByteArrayOutputStream();
+			setOut(new PrintStream(captureOutputStream));
+			executeRuleWithStatement(log, new WriteTextToStandardOutputStreamWithoutFailure());
+			assertThat(captureOutputStream, hasToString(isEmptyString()));
+		} finally {
+			setOut(originalStream);
+		}
+	}
+
+	@Test
+	public void doesWriteToOutputLogForLogOnFailureModeWithoutFailure() throws Throwable {
+		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		PrintStream originalStream = out;
+		try {
+			ByteArrayOutputStream captureOutputStream = new ByteArrayOutputStream();
+			setOut(new PrintStream(captureOutputStream));
+			executeRuleWithStatement(log, new WriteTextToStandardOutputStreamWithoutFailure());
+			assertThat(log.getLog(), is(equalTo(ARBITRARY_TEXT)));
+		} finally {
+			setOut(originalStream);
+		}
+	}
+
+	@Test
+	public void doesWriteToSystemOutputStreamForLogOnFailureModeWithFailure() throws Throwable {
+		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		PrintStream originalStream = out;
+		ByteArrayOutputStream captureOutputStream = new ByteArrayOutputStream();
+		try {
+			setOut(new PrintStream(captureOutputStream));
+			executeRuleWithStatement(log, new WriteTextToStandardOutputStreamWithFailure());
+		} catch (IgnoredException ignored) {
+			assertThat(captureOutputStream, hasToString(equalTo(ARBITRARY_TEXT)));
+		} finally {
+			setOut(originalStream);
+		}
+	}
+
+	@Test
+	public void doesWriteToOutputLogForLogOnFailureModeWithFailure() throws Throwable {
+		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		PrintStream originalStream = out;
+		try {
+			ByteArrayOutputStream captureOutputStream = new ByteArrayOutputStream();
+			setOut(new PrintStream(captureOutputStream));
+			executeRuleWithStatement(log, new WriteTextToStandardOutputStreamWithFailure());
+		} catch (IgnoredException ignored) {
+			assertThat(log.getLog(), is(equalTo(ARBITRARY_TEXT)));
+		} finally {
+			setOut(originalStream);
+		}
+	}
+
+	@Test
+	public void doesNotWriteToSystemErrorStreamForLogOnFailureModeWithoutFailure() throws Throwable {
+		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		PrintStream originalStream = err;
+		try {
+			ByteArrayOutputStream captureErrorStream = new ByteArrayOutputStream();
+			setErr(new PrintStream(captureErrorStream));
+			executeRuleWithStatement(log, new WriteTextToStandardErrorStreamWithoutFailure());
+			assertThat(captureErrorStream, hasToString(isEmptyString()));
+		} finally {
+			setErr(originalStream);
+		}
+	}
+
+	@Test
+	public void doesWriteToErrorLogForLogOnFailureModeWithoutFailure() throws Throwable {
+		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		PrintStream originalStream = err;
+		try {
+			ByteArrayOutputStream captureErrorStream = new ByteArrayOutputStream();
+			setErr(new PrintStream(captureErrorStream));
+			executeRuleWithStatement(log, new WriteTextToStandardErrorStreamWithoutFailure());
+			assertThat(log.getLog(), is(equalTo(ARBITRARY_TEXT)));
+		} finally {
+			setErr(originalStream);
+		}
+	}
+
+	@Test
+	public void doesWriteToSystemErrorStreamForLogOnFailureModeWithFailure() throws Throwable {
+		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		PrintStream originalStream = err;
+		ByteArrayOutputStream captureErrorStream = new ByteArrayOutputStream();
+		try {
+			setErr(new PrintStream(captureErrorStream));
+			executeRuleWithStatement(log, new WriteTextToStandardErrorStreamWithFailure());
+		} catch (IgnoredException ignored) {
+			assertThat(captureErrorStream, hasToString(equalTo(ARBITRARY_TEXT)));
+		} finally {
+			setErr(originalStream);
+		}
+	}
+
+	@Test
+	public void doesWriteToErrorLogForLogOnFailureModeWithFailure() throws Throwable {
+		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		PrintStream originalStream = err;
+		try {
+			ByteArrayOutputStream captureErrorStream = new ByteArrayOutputStream();
+			setErr(new PrintStream(captureErrorStream));
+			executeRuleWithStatement(log, new WriteTextToStandardErrorStreamWithFailure());
+		} catch (IgnoredException ignored) {
+			assertThat(log.getLog(), is(equalTo(ARBITRARY_TEXT)));
+		} finally {
+			setErr(originalStream);
+		}
+	}
+
+	private void executeRuleWithStatement(TestRule rule, Statement statement) throws Throwable {
+		rule.apply(statement, null).evaluate();
+	}
+
+	private class WriteTextToStandardOutputStreamWithoutFailure extends Statement {
+		@Override
+		public void evaluate() throws Throwable {
+			out.print(ARBITRARY_TEXT);
+		}
+	}
+
+	private class WriteTextToStandardOutputStreamWithFailure extends Statement {
+		@Override
+		public void evaluate() throws Throwable {
+			out.print(ARBITRARY_TEXT);
+			throw new IgnoredException();
+		}
+	}
+
+	private class WriteTextToStandardErrorStreamWithoutFailure extends Statement {
+		@Override
+		public void evaluate() throws Throwable {
+			err.print(ARBITRARY_TEXT);
+		}
+	}
+
+	private class WriteTextToStandardErrorStreamWithFailure extends Statement {
+		@Override
+		public void evaluate() throws Throwable {
+			err.print(ARBITRARY_TEXT);
+			throw new IgnoredException();
+		}
+	}
+
+	private class IgnoredException extends Exception {
+	}
+}

--- a/src/test/java/org/junit/contrib/java/lang/system/PrintStreamLogOnFailureTest.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/PrintStreamLogOnFailureTest.java
@@ -54,7 +54,7 @@ public class PrintStreamLogOnFailureTest {
 
 	@Test
 	public void doesNotWriteToSystemOutputStreamForLogOnFailureModeWithoutFailure() throws Throwable {
-		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY);
 		PrintStream originalStream = out;
 		try {
 			ByteArrayOutputStream captureOutputStream = new ByteArrayOutputStream();
@@ -68,7 +68,7 @@ public class PrintStreamLogOnFailureTest {
 
 	@Test
 	public void doesWriteToOutputLogForLogOnFailureModeWithoutFailure() throws Throwable {
-		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY);
 		PrintStream originalStream = out;
 		try {
 			ByteArrayOutputStream captureOutputStream = new ByteArrayOutputStream();
@@ -82,7 +82,7 @@ public class PrintStreamLogOnFailureTest {
 
 	@Test
 	public void doesWriteToSystemOutputStreamForLogOnFailureModeWithFailure() throws Throwable {
-		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY);
 		PrintStream originalStream = out;
 		ByteArrayOutputStream captureOutputStream = new ByteArrayOutputStream();
 		try {
@@ -97,7 +97,7 @@ public class PrintStreamLogOnFailureTest {
 
 	@Test
 	public void doesWriteToOutputLogForLogOnFailureModeWithFailure() throws Throwable {
-		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		StandardOutputStreamLog log = new StandardOutputStreamLog(LogMode.LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY);
 		PrintStream originalStream = out;
 		try {
 			ByteArrayOutputStream captureOutputStream = new ByteArrayOutputStream();
@@ -112,7 +112,7 @@ public class PrintStreamLogOnFailureTest {
 
 	@Test
 	public void doesNotWriteToSystemErrorStreamForLogOnFailureModeWithoutFailure() throws Throwable {
-		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY);
 		PrintStream originalStream = err;
 		try {
 			ByteArrayOutputStream captureErrorStream = new ByteArrayOutputStream();
@@ -126,7 +126,7 @@ public class PrintStreamLogOnFailureTest {
 
 	@Test
 	public void doesWriteToErrorLogForLogOnFailureModeWithoutFailure() throws Throwable {
-		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY);
 		PrintStream originalStream = err;
 		try {
 			ByteArrayOutputStream captureErrorStream = new ByteArrayOutputStream();
@@ -140,7 +140,7 @@ public class PrintStreamLogOnFailureTest {
 
 	@Test
 	public void doesWriteToSystemErrorStreamForLogOnFailureModeWithFailure() throws Throwable {
-		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY);
 		PrintStream originalStream = err;
 		ByteArrayOutputStream captureErrorStream = new ByteArrayOutputStream();
 		try {
@@ -155,7 +155,7 @@ public class PrintStreamLogOnFailureTest {
 
 	@Test
 	public void doesWriteToErrorLogForLogOnFailureModeWithFailure() throws Throwable {
-		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_ONLY_ON_FAILURE);
+		StandardErrorStreamLog log = new StandardErrorStreamLog(LogMode.LOG_AND_WRITE_TO_STREAM_ON_FAILURE_ONLY);
 		PrintStream originalStream = err;
 		try {
 			ByteArrayOutputStream captureErrorStream = new ByteArrayOutputStream();


### PR DESCRIPTION
Add a new mode, log-on-failure. It should:

* Continue appending to the saved log
* Print to the original streams for failed tests
* This is designed to improve developer convenience, keeping passing tests quiet and making failing tests noisy.

Rebased as suggested.  I also squashed some commits to make it clearer what you are getting:

* Commit binkley/system-rules@fb4c976 could be cherry-picked separately; it has `PrintStreamLog` extends `TestWatcher` rather than `ExternalResource`
* Commit binkley/system-rules@cc86caf add log-on-failure mode, requiring previous commit to get at `TestWatcher#failed(Throwable, Description)`.

Cheers,
--binkley