### PR TITLE
Add method to provide multiple lines of input

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 			<id>marcphilipp</id>
 			<name>Marc Philipp</name>
 			<email>mail@marcphilipp.de</email>
-			<url>http://marcphilipp.tumblr.com/</url>
+			<url>http://www.marcphilipp.de/</url>
 			<timezone>+1</timezone>
 		</developer>
 		<developer>

--- a/src/main/java/org/junit/contrib/java/lang/system/TextFromStandardInputStream.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/TextFromStandardInputStream.java
@@ -76,7 +76,25 @@ public class TextFromStandardInputStream extends ExternalResource {
 	public void provideText(String... texts) {
 		systemInMock.provideText(asList(texts));
 	}
-
+	
+	/**
+	 * Set the lines that are returned by {@code System.in},
+	 * each in a new line separated by System.lineSeperator().
+	 * You can provide multiple lines. In that case {@code System.in.read()}
+	 * returns -1 once when the end of a single text is reached and
+	 * continues with the next text afterwards.
+	 * @param lines a list of lines.
+	 */
+	public void provideLines(String... lines) {
+		String[] texts = new String[lines.length];
+		
+		for (int index = 0; index < lines.length; index++) {
+			texts[index] = lines[index] + System.lineSeparator();
+		}
+		
+		provideText(texts);
+	}
+	
 	@Override
 	protected void before() throws Throwable {
 		originalIn = in;
@@ -120,8 +138,5 @@ public class TextFromStandardInputStream extends ExternalResource {
 		}
 	}
 
-	public void provideLines(String string, String string2) {
-		// TODO Auto-generated method stub
-		
-	}
+	
 }

--- a/src/main/java/org/junit/contrib/java/lang/system/TextFromStandardInputStream.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/TextFromStandardInputStream.java
@@ -79,7 +79,7 @@ public class TextFromStandardInputStream extends ExternalResource {
 	
 	/**
 	 * Set the lines that are returned by {@code System.in},
-	 * each in a new line separated by System.lineSeperator().
+	 * each in a new line separated by System.getProperty("line.separator").
 	 * You can provide multiple lines. In that case {@code System.in.read()}
 	 * returns -1 once when the end of a single text is reached and
 	 * continues with the next text afterwards.
@@ -89,7 +89,7 @@ public class TextFromStandardInputStream extends ExternalResource {
 		String[] texts = new String[lines.length];
 		
 		for (int index = 0; index < lines.length; index++) {
-			texts[index] = lines[index] + System.lineSeparator();
+			texts[index] = lines[index] + System.getProperty("line.separator");
 		}
 		
 		provideText(texts);

--- a/src/main/java/org/junit/contrib/java/lang/system/TextFromStandardInputStream.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/TextFromStandardInputStream.java
@@ -119,4 +119,9 @@ public class TextFromStandardInputStream extends ExternalResource {
 				currentReader = null;
 		}
 	}
+
+	public void provideLines(String string, String string2) {
+		// TODO Auto-generated method stub
+		
+	}
 }

--- a/src/test/java/org/junit/contrib/java/lang/system/TextFromStandardInputStreamTest.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/TextFromStandardInputStreamTest.java
@@ -47,7 +47,20 @@ public class TextFromStandardInputStreamTest {
 			}
 		});
 	}
-
+	@Test
+	public void providesMultipleTextsEachWithANewLine() throws Throwable {
+		executeRuleWithStatement(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				systemInMock.provideLines("first text", "second text");
+				Scanner firstScanner = new Scanner(System.in);
+				firstScanner.nextLine();
+				Scanner secondScanner = new Scanner(System.in);
+				String textFromSystemIn = secondScanner.nextLine();
+				assertThat(textFromSystemIn, is(equalTo("second text")));
+			}
+		});
+	}
 	@Test
 	public void doesNotFailForNoProvidedText() throws Throwable {
 		executeRuleWithStatement(new Statement() {

--- a/src/test/java/org/junit/contrib/java/lang/system/TextFromStandardInputStreamTest.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/TextFromStandardInputStreamTest.java
@@ -47,6 +47,7 @@ public class TextFromStandardInputStreamTest {
 			}
 		});
 	}
+	
 	@Test
 	public void providesMultipleTextsEachWithANewLine() throws Throwable {
 		executeRuleWithStatement(new Statement() {
@@ -61,6 +62,7 @@ public class TextFromStandardInputStreamTest {
 			}
 		});
 	}
+	
 	@Test
 	public void doesNotFailForNoProvidedText() throws Throwable {
 		executeRuleWithStatement(new Statement() {


### PR DESCRIPTION
**A new convenient method to provide multiple lines of input**

Calls *TextFromStandardInputStream.provideText()*, but adds a *System.getProperty("line.separator")* after each parameter so that doesn't have to be done in the test using *TextFromStandardInputStream*.

I also updated Marc's URL, as the current one is outdated.