### PR TITLE
set commons-io version to avoid SNAPSHOT version, even if system rule…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>[2,3)</version>
+			<version>2.4</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
…s is used in test scope