### PR TITLE
Add ProvideSecurityProvider rule

### DIFF
--- a/src/main/java/org/junit/contrib/java/lang/system/ProvideSecurityProvider.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/ProvideSecurityProvider.java
@@ -1,0 +1,47 @@
+package org.junit.contrib.java.lang.system;
+
+import java.security.Provider;
+import java.security.Security;
+
+import org.junit.rules.ExternalResource;
+
+/**
+ * The {@code ProvideSecurityProvider} rule provides an arbitrary security
+ * provider to a test. After the test, the security provider is removed.
+ *
+ * <pre>
+ *   public void MyTest {
+ *     private final MySecurityProvider securityProvider
+ *       = new MySecurityProvider();
+ *
+ *     &#064;Rule
+ *     public final ProvideSecurityProvider provideSecurityProvider
+ *       = new ProvideSecurityProvider(securityProvider);
+ *
+ *     &#064;Test
+ *     public void useCustomDigestImplementation() {
+ *       assertThat(MessageDigest.getInstance("SHA-3", "test")).isNotNull();
+ *     }
+ *   }
+ * </pre>
+ */
+public class ProvideSecurityProvider extends ExternalResource {
+	private int position;
+	private final Provider provider;
+
+	public ProvideSecurityProvider(Provider provider) {
+		this.provider = provider;
+	}
+	@Override
+	protected void before() throws Throwable {
+		position = Security.addProvider(provider);
+	}
+
+	@Override
+	protected void after() {
+		if (position == -1) {
+			return;
+		}
+		Security.removeProvider(provider.getName());
+	}
+}

--- a/src/test/java/org/junit/contrib/java/lang/system/ProvideSecurityProviderTest.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/ProvideSecurityProviderTest.java
@@ -1,0 +1,56 @@
+package org.junit.contrib.java.lang.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.contrib.java.lang.system.Executor.executeTestWithRule;
+
+import java.security.Provider;
+import java.security.Security;
+
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+
+import sun.security.jca.Providers;
+
+public class ProvideSecurityProviderTest {
+	@Test
+	public void rule_is_added() {
+		ProvideSecurityProvider rule = new ProvideSecurityProvider(new TestProvider());
+		executeTestWithRule(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				assertThat(Providers.getProviderList().getProvider("test"))
+					.isNotNull()
+					.isInstanceOf(TestProvider.class);
+			}
+		}, rule);
+	}
+
+	@Test
+	public void rule_is_removed_if_new() {
+		ProvideSecurityProvider rule = new ProvideSecurityProvider(new TestProvider());
+		executeTestWithRule(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+			}
+		}, rule);
+		assertThat(Providers.getProviderList().getProvider("test"))
+			.isNull();
+	}
+
+	@Test
+	public void rule_is_not_removed_if_not_new() {
+		TestProvider provider = new TestProvider();
+		ProvideSecurityProvider rule = new ProvideSecurityProvider(new TestProvider());
+		int position = Security.addProvider(provider);
+		assertThat(position).isNotEqualTo(-1);
+		executeTestWithRule(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+			}
+		}, rule);
+		assertThat(Providers.getProviderList().getProvider("test"))
+			.isNotNull()
+			.isInstanceOf(TestProvider.class);
+		Security.removeProvider("test");
+	}
+}

--- a/src/test/java/org/junit/contrib/java/lang/system/TestProvider.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/TestProvider.java
@@ -1,0 +1,9 @@
+package org.junit.contrib.java.lang.system;
+
+import java.security.Provider;
+
+public class TestProvider extends Provider {
+	protected TestProvider() {
+		super("test", 0.1, "test");
+	}
+}


### PR DESCRIPTION
The ProvideSecurityProvider rule provides an arbitrary SecurityProvider
to a test. After the test, the security provider is removed.