### PR TITLE
Sometimes i need to test some underlying code which closes the standa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .flattened-pom.xml
 target
+/.idea/
+/.mvn/
+.idea/
+system-rules.iml

--- a/src/main/java/org/junit/contrib/java/lang/system/SystemOutRule.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/SystemOutRule.java
@@ -181,6 +181,11 @@ public class SystemOutRule implements TestRule {
 		return this;
 	}
 
+	public SystemOutRule untrack() {
+		logPrintStream.unTrackOriginalStream();
+		return this;
+	}
+
 	/**
 	 * Suppress the output to {@code System.out} for successful tests only.
 	 * The output is still written to {@code System.out} for failing tests.

--- a/src/main/java/org/junit/contrib/java/lang/system/internal/LogPrintStream.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/internal/LogPrintStream.java
@@ -11,11 +11,11 @@ import static java.lang.System.getProperty;
 
 public class LogPrintStream {
 	private final PrintStreamHandler printStreamHandler;
-	private final MuteableLogStream muteableLogStream;
+	private final MutableLogStream mutableLogStream;
 
 	public LogPrintStream(PrintStreamHandler printStreamHandler) {
 		this.printStreamHandler = printStreamHandler;
-		this.muteableLogStream = new MuteableLogStream(printStreamHandler.getStream());
+		this.mutableLogStream = new MutableLogStream(printStreamHandler.getStream());
 	}
 
 	public Statement createStatement(final Statement base) {
@@ -26,12 +26,12 @@ public class LogPrintStream {
 					printStreamHandler.createRestoreStatement(new Statement() {
 						@Override
 						public void evaluate() throws Throwable {
-							printStreamHandler.replaceCurrentStreamWithOutputStream(muteableLogStream);
+							printStreamHandler.replaceCurrentStreamWithOutputStream(mutableLogStream);
 							base.evaluate();
 						}
 					}).evaluate();
 				} catch (Throwable e) {
-					muteableLogStream.failureLog.writeTo(printStreamHandler.getStream());
+					mutableLogStream.failureLog.writeTo(printStreamHandler.getStream());
 					throw e;
 				}
 			}
@@ -39,15 +39,15 @@ public class LogPrintStream {
 	}
 
 	public void clearLog() {
-		muteableLogStream.log.reset();
+		mutableLogStream.log.reset();
 	}
 
 	public void enableLog() {
-		muteableLogStream.logMuted = false;
+		mutableLogStream.logMuted = false;
 	}
 
 	public String getLog() {
-		/* The MuteableLogStream is created with the default encoding
+		/* The MutableLogStream is created with the default encoding
 		 * because it writes to System.out or System.err if not muted and
 		 * System.out/System.err uses the default encoding. As a result all
 		 * other streams receive input that is encoded with the default
@@ -55,7 +55,7 @@ public class LogPrintStream {
 		 */
 		String encoding = getProperty("file.encoding");
 		try {
-			return muteableLogStream.log.toString(encoding);
+			return mutableLogStream.log.toString(encoding);
 		} catch (UnsupportedEncodingException e) {
 			throw new RuntimeException(e);
 		}
@@ -67,23 +67,27 @@ public class LogPrintStream {
 	}
 
 	public void mute() {
-		muteableLogStream.originalStreamMuted = true;
+		mutableLogStream.originalStreamMuted = true;
+	}
+	public void unTrackOriginalStream(){
+		mutableLogStream.trackOriginalStream = false;
 	}
 
 	public void muteForSuccessfulTests() {
 		mute();
-		muteableLogStream.failureLogMuted = false;
+		mutableLogStream.failureLogMuted = false;
 	}
 
-	private static class MuteableLogStream extends OutputStream {
+	private static class MutableLogStream extends OutputStream {
 		final OutputStream originalStream;
 		final ByteArrayOutputStream failureLog = new ByteArrayOutputStream();
 		final ByteArrayOutputStream log = new ByteArrayOutputStream();
 		boolean originalStreamMuted = false;
 		boolean failureLogMuted = true;
 		boolean logMuted = true;
+		boolean trackOriginalStream = true;
 
-		MuteableLogStream(OutputStream originalStream) {
+		MutableLogStream(OutputStream originalStream) {
 			this.originalStream = originalStream;
 		}
 
@@ -99,13 +103,17 @@ public class LogPrintStream {
 
 		@Override
 		public void flush() throws IOException {
-			originalStream.flush();
-			//ByteArrayOutputStreams don't have to be closed
+			if (trackOriginalStream) {
+				originalStream.flush();
+			}
+			//ByteArrayOutputStreams don't have to be flushed
 		}
 
 		@Override
 		public void close() throws IOException {
-			originalStream.close();
+			if (trackOriginalStream) {
+				originalStream.close();
+			}
 			//ByteArrayOutputStreams don't have to be closed
 		}
 	}


### PR DESCRIPTION
…rd output stream, which leads to wrong behaviour of the JUnit tests. They are shown as not run.

Also in case of multiple invocation of underlying code which closes the output stream the JVM System.out is not available after the first execution.
This patch will allow to prevent close original output stream by givin this control to test righter