### PR TITLE
pom: Use "junit" instead of the deprecated "junit-dep" artifact name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
-			<artifactId>junit-dep</artifactId>
+			<artifactId>junit</artifactId>
 			<version>[4.9,)</version>
 		</dependency>
 


### PR DESCRIPTION
"junit-dep" was moved to "junit", see the notice in the header of

https://mvnrepository.com/artifact/junit/junit-dep