### PR TITLE
Add methods to access raw stdout/stderr logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ System Rules is available from
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
-      <version>1.18.0</version>
+      <version>1.19.0</version>
     </dependency>
 
 Please don't forget to add the scope `test` if you're using System

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>system-rules</artifactId>
-	<version>1.19.0-SNAPSHOT</version>
+	<version>1.19.0</version>
 	<packaging>jar</packaging>
 
 	<name>System Rules</name>

--- a/src/main/java/org/junit/contrib/java/lang/system/SystemErrRule.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/SystemErrRule.java
@@ -49,6 +49,23 @@ import org.junit.runners.model.Statement;
  * }
  * </pre>
  *
+ * <p>If your code under test writes raw binary data to {@code System.err} then
+ * you can read it by means of {@link #getLogAsBytes()}).
+ *
+ * <pre>
+ * public class SystemErrTest {
+ *   &#064;Rule
+ *   public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+ *
+ *   &#064;Test
+ *   public void test() {
+ *     byte[] data = { 1, 2, 3, 4, 5 };
+ *     System.err.write(data, 0, data.length);
+ *     assertEquals(data, systemErrRule.{@link #getLogAsBytes()});
+ *   }
+ * }
+ * </pre>
+ *
  * <p>You don't have to enable logging for every test. It can be enabled for
  * specific tests only.
  *
@@ -219,6 +236,17 @@ public class SystemErrRule implements TestRule {
 	 */
 	public String getLogWithNormalizedLineSeparator() {
 		return logPrintStream.getLogWithNormalizedLineSeparator();
+	}
+
+	/**
+	 * Returns the raw bytes that are written to {@code System.err} since
+	 * {@link #enableLog()} (respectively {@link #clearLog()} has been called.
+	 *
+	 * @return the raw bytes that are written to {@code System.err} since
+	 * {@link #enableLog()} (respectively {@link #clearLog()} has been called.
+	 */
+	public byte[] getLogAsBytes() {
+		return logPrintStream.getLogAsBytes();
 	}
 
 	/**

--- a/src/main/java/org/junit/contrib/java/lang/system/SystemOutRule.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/SystemOutRule.java
@@ -49,6 +49,23 @@ import org.junit.runners.model.Statement;
  * }
  * </pre>
  *
+ * <p>If your code under test writes raw binary data to {@code System.out} then
+ * you can read it by means of {@link #getLogAsBytes()}).
+ *
+ * <pre>
+ * public class SystemOutTest {
+ *   &#064;Rule
+ *   public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+ *
+ *   &#064;Test
+ *   public void test() {
+ *     byte[] data = { 1, 2, 3, 4, 5 };
+ *     System.out.write(data, 0, data.length);
+ *     assertEquals(data, systemOutRule.{@link #getLogAsBytes()});
+ *   }
+ * }
+ * </pre>
+ *
  * <p>You don't have to enable logging for every test. It can be enabled for
  * specific tests only.
  *
@@ -219,6 +236,17 @@ public class SystemOutRule implements TestRule {
 	 */
 	public String getLogWithNormalizedLineSeparator() {
 		return logPrintStream.getLogWithNormalizedLineSeparator();
+	}
+
+	/**
+	 * Returns the raw bytes that are written to {@code System.out} since
+	 * {@link #enableLog()} (respectively {@link #clearLog()} has been called.
+	 *
+	 * @return the raw bytes that are written to {@code System.out} since
+	 * {@link #enableLog()} (respectively {@link #clearLog()} has been called.
+	 */
+	public byte[] getLogAsBytes() {
+		return logPrintStream.getLogAsBytes();
 	}
 
 	/**

--- a/src/main/java/org/junit/contrib/java/lang/system/internal/LogPrintStream.java
+++ b/src/main/java/org/junit/contrib/java/lang/system/internal/LogPrintStream.java
@@ -66,6 +66,10 @@ public class LogPrintStream {
 		return getLog().replace(lineSeparator, "\n");
 	}
 
+	public byte[] getLogAsBytes() {
+		return muteableLogStream.log.toByteArray();
+	}
+
 	public void mute() {
 		muteableLogStream.originalStreamMuted = true;
 	}

--- a/src/test/java/org/junit/contrib/java/lang/system/SystemErrRuleTest.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/SystemErrRuleTest.java
@@ -373,4 +373,17 @@ public class SystemErrRuleTest {
 			assertThat(failures).isEmpty();
 		}
 	}
+
+	public static class raw_bytes_of_output_are_available_when_logging_is_enabled {
+		@Rule
+		public final SystemErrRule systemErrRule = new SystemErrRule()
+			.enableLog();
+
+		@Test
+		public void test() {
+			byte[] data = { 1, 2, 3, 4, 5 };
+			System.err.write(data, 0, data.length);
+			assertThat(systemErrRule.getLogAsBytes()).isEqualTo(data);
+		}
+	}
 }

--- a/src/test/java/org/junit/contrib/java/lang/system/SystemOutRuleTest.java
+++ b/src/test/java/org/junit/contrib/java/lang/system/SystemOutRuleTest.java
@@ -372,4 +372,17 @@ public class SystemOutRuleTest {
 			assertThat(failures).isEmpty();
 		}
 	}
+
+	public static class raw_bytes_of_output_are_available_when_logging_is_enabled {
+		@Rule
+		public final SystemOutRule systemOutRule = new SystemOutRule()
+			.enableLog();
+
+		@Test
+		public void test() {
+			byte[] data = { 1, 2, 3, 4, 5 };
+			System.out.write(data, 0, data.length);
+			assertThat(systemOutRule.getLogAsBytes()).isEqualTo(data);
+		}
+	}
 }


### PR DESCRIPTION
I would like to test some code that writes raw binary data to stdout. To do so I believe I need access to the underlying byte array, since a sequence of bytes may not be a valid string. Therefore I suggest to add a method `getLogBytes` to `SystemOutRule` and `SystemErrRule`. Let me know if you think this makes sense and if so I will add documentation and tests to this PR.
