### PR TITLE
Update lib-parent to version 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# openjdk-6-jdk is not available in more recent Ubuntu versions
+dist: trusty
 language: java
 install:
   # Download dependencies with JDK 8 because Maven Central supports
@@ -23,4 +25,10 @@ jdk:
   - oraclejdk9
   - oraclejdk8
   - openjdk7
-  - openjdk6
+
+# The jdk key does not work for openjdk6 in Travis CI any more, so
+# we manually install openjdk-6-jdk and set JAVA_HOME appropriately
+# (https://github.com/travis-ci/travis-ci/issues/9713)
+matrix:
+  include:
+  - env: JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.stefanbirkner</groupId>
 		<artifactId>lib-parent</artifactId>
-		<version>8</version>
+		<version>14</version>
 	</parent>
 
 	<artifactId>system-rules</artifactId>


### PR DESCRIPTION
Building with Maven 3.6.2 currently fails with
```
[ERROR] Failed to execute goal org.codehaus.mojo:findbugs-maven-plugin:3.0.1:findbugs (findbugs) on project system-rules: Unable to parse configuration of mojo org.codehaus.mojo:findbugs-maven-plugin:3.0.1:findbugs for parameter pluginArtifacts: Cannot assign configuration entry 'pluginArtifacts' with value '${plugin.artifacts}' of type java.util.Collections.UnmodifiableRandomAccessList to property of type java.util.ArrayList -> [Help 1]
```
This is resolved in FindBugs version 3.0.4 and newer, so update [lib-parent](https://github.com/stefanbirkner/lib-parent) to a version including this fix. Using lib-parent version >14 breaks the current CI setup due to requiring a more recent Maven version.